### PR TITLE
Added psuedo-support for `OUT` and `OIN` opcodes

### DIFF
--- a/TARNII.txt
+++ b/TARNII.txt
@@ -74,7 +74,7 @@ TARNII has 16 opcodes, those being:
 0x04:	OIN	= pull the MREQ line high, pull the IORQ line low, set the address bus to [ADDRPOP], push the value on the data bus onto the stack. do these in order
 0x08:	STO	= pull the MREQ line low, set the address bus to [ADDRPOP], set the data bus to number A of [VALPOP]. do these in order
 0x10:	LOD	= pull the MREQ line low, set the address bus to [ADDRPOP], push the value on the data bus to the stack. do these in order
-0xBB:	HLT	= halt the cpu until a REST signal is recieved
+0xBB:	HLT	= halt the cpu until a REST signal (rising edge) is recieved
 
 ## CODE EXAMPLES ##
 How to add two numbers:

--- a/include/logger.h
+++ b/include/logger.h
@@ -5,4 +5,6 @@
 
 void writeState(FILE * fp);
 
+void writeIO(FILE * fp);
+
 #endif

--- a/readme.txt
+++ b/readme.txt
@@ -1,1 +1,3 @@
 ALL PROGRAMS must end in 0xBB/the HLT opcode
+
+in order to use OUT and OIN, you must use the flag '-io' at the end of the tarnii-emu argument list

--- a/src/io.c
+++ b/src/io.c
@@ -4,6 +4,9 @@
 #include <registers.h>
 
 unsigned char iorq = 0x00;
+unsigned char mreq = 0x00;
+unsigned char rdwr = 0x00;
+unsigned char rest = 0x00;
 
 unsigned short addrBus = 0x0000;
 unsigned char dataBus = 0x00;

--- a/src/logger.c
+++ b/src/logger.c
@@ -5,9 +5,20 @@
 #include <logger.h> 
 
 void writeState(FILE * fp){
-	fprintf(fp,"Program Counter: %x | ",programCounter);
-	fprintf(fp,"Stack Pointer: %x\n",stackPointer);
-	fprintf(fp,"Zero Flag: %x | ",zeroFlag);
-	fprintf(fp,"Carry Flag: %x | ",carryFlag);
-	fprintf(fp,"Equal Flag: %x\n",equalFlag);
+	fprintf(fp,"Program Counter: %X | ",programCounter);
+	fprintf(fp,"Stack Pointer: %X\n",stackPointer);
+	fprintf(fp,"Zero Flag: %X | ",zeroFlag);
+	fprintf(fp,"Carry Flag: %X | ",carryFlag);
+	fprintf(fp,"Equal Flag: %X\n",equalFlag);
+}
+
+void writeIO(FILE * fp){
+	fprintf(fp,"###\n");
+	fprintf(fp,"PC %X\n",programCounter);
+	fprintf(fp,"ADDR %X\n",addrBus);
+	fprintf(fp,"DATA %X\n",dataBus);
+	fprintf(fp,"IORQ %X\n",iorq);
+	fprintf(fp,"MREQ %X\n",mreq);
+	fprintf(fp,"RDWR %X\n",rdwr);
+	fprintf(fp,"REST %X\n",rest);
 }


### PR DESCRIPTION
Added:
- Support for the `OUT` and `OIN` opcodes, specific to the emulator
  - `OUT` performs a `[VALPOP]` then prints argument `A` to the terminal as an ascii character
  - `OIN` gets a single ascii character from `stdin` and pushes it to the stack
  - These behaviours will eventually be phased out in favour of the behaviour specified in `TARNII.txt`

Removed:
- CPU state output while a program is running 